### PR TITLE
Makes DNS resolution bypass possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ See TrustFully API's documentation.
 $ composer require trustfully/trustfully-api-client-php
 ```
 
+## Usage
+
 ```php
 <?php
 
@@ -43,4 +45,13 @@ try {
 } catch (\Exception $e) {
     die($e->getMessage());
 }
+```
+
+Alternatively, you can specify a host to bypass DNS resolution when instanciating the client:
+
+```php
+<?php
+
+    $client = new TrustFully\Client('https://10.17.10.17/v1/', 'CLIENT_API_KEY', 'api.trustfully.com');
+
 ```

--- a/src/TrustFully/Client.php
+++ b/src/TrustFully/Client.php
@@ -80,13 +80,20 @@ class Client implements ClientInterface
     private $responseCode = null;
 
     /**
+     * @var string
+     */
+    private $host;
+
+    /**
      * @param string $url
      * @param string $xApiKey
+     * @param string $host
      */
-    public function __construct($url, $xApiKey)
+    public function __construct($url, $xApiKey, $host = null)
     {
         $this->url = $url;
         $this->xApiKey = $xApiKey;
+        $this->host = $host;
         $this->getPort();
     }
 
@@ -314,10 +321,11 @@ class Client implements ClientInterface
         $requestHeader = [
             'content-type: multipart/form-data',
             'cache-control: no-cache',
-            // 'Expect:',
             sprintf('X-Api-Key: %s', $this->xApiKey),
-            // 'Content-Type: application/json',
         ];
+        if(null !== $this->host) {
+            $requestHeader[] = sprintf('Host: %s', $this->host);
+        }
         if (null !== $this->apiToken) {
             $requestHeader[] = sprintf('Authorization: Bearer %s', $this->apiToken);
         }


### PR DESCRIPTION
It’s not possible to use the client on local env, because it asks remote DNS for local hostnames.

This PR adds the possibility to specify an IP as URL and a hostname. This way, curl makes no DNS resolution.